### PR TITLE
Add vitest-snap repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@
 - [**vitest-image-snapshot**](https://github.com/wgsl-tooling-wg/wesl-js/tree/main/tools/packages/vitest-image-snapshot) — Visual regression testing for images.
 - [**vitest-package-exports**](https://github.com/antfu/vitest-package-exports) — Guard exported APIs against unintended breaking changes.
 - [**vitest-react-serializer**](https://github.com/porada/vitest-react-serializer) — Serialize React components into formatted HTML.
-- [**vitest-snap**](https://github.com/Odonno/vitest-snap) — The perfect matchers for Vitest snaphost testing.
+- [**vitest-snap**](https://github.com/Odonno/vitest-snap) — Snapshot data into text, JSON, YAML, and Markdown files.
 - [**vitest-snapshot-tools**](https://github.com/atombarel/vitest-snapshot-tools) — Review snapshot updates in a local UI and selectively apply them.
 - [**vue3-snapshot-serializer**](https://github.com/tjw-lint/vue3-snapshot-serializer) — Serialize Vue 3 components into formatted HTML.
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@
 - [**vitest-image-snapshot**](https://github.com/wgsl-tooling-wg/wesl-js/tree/main/tools/packages/vitest-image-snapshot) — Visual regression testing for images.
 - [**vitest-package-exports**](https://github.com/antfu/vitest-package-exports) — Guard exported APIs against unintended breaking changes.
 - [**vitest-react-serializer**](https://github.com/porada/vitest-react-serializer) — Serialize React components into formatted HTML.
+- [**vitest-snap**](https://github.com/Odonno/vitest-snap) — The perfect matchers for Vitest snaphost testing.
 - [**vitest-snapshot-tools**](https://github.com/atombarel/vitest-snapshot-tools) — Review snapshot updates in a local UI and selectively apply them.
 - [**vue3-snapshot-serializer**](https://github.com/tjw-lint/vue3-snapshot-serializer) — Serialize Vue 3 components into formatted HTML.
 


### PR DESCRIPTION
## Details

Why `vitest-snap` in a few bullet points:
* Easy to use, start with `toJsonSnapshot()` for standard snapshot testing
* Supports multiple data formats: JSON, YAML, Markdown or basic text (for primitive types)
* 1st class TypeScript support (e.g. union type of a set of `selectors` derived from the asserted type = no error possible)
* `filters`: used when you only snapshot part of an object/array
* `redactions`: used when you want to rewrite the output value (useful for random generated data, e.g. dates, uuid, etc..)
* Fully extensible: extends wtih custom filters & redactions based on your needs
* Global & per-snapshot configuration

Documentation link: https://vitest-snap.vercel.app/ 

## Submission Notes

<!-- Please keep this section and mark all applicable items -->

- [x] This pull request adds a single Vitest-specific resource that follows the [contributing guidelines](https://github.com/porada/awesome-vitest/blob/main/CONTRIBUTING.md).
- [x] I’ve personally used this tool and can vouch for it (if applicable).
