### PR TITLE
Add @qualflare/vitest

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@
 
 ### Reporters
 
-- [**@qualflare/vitest**](https://github.com/Qualflare/qualflare-vitest) — Reports results, retries, flakiness and nested steps to the Qualflare test-management platform. Makes no network calls; a separate CLI step uploads, so sharded runs merge into one report.
+- [**@qualflare/vitest**](https://github.com/Qualflare/qualflare-vitest) — Qualflare reporter.
 - [**@testream/vitest-reporter**](https://docs.testream.app/reporters/vitest) — Teststream reporter with Jira integration.
 - [**vitest-llm-reporter**](https://github.com/hansjm10/vitest-llm-reporter) — Structured JSON output optimized for LLM parsing, with streaming support.
 - [**vitest-md-reporter**](https://github.com/robertozmc/vitest-md-reporter) — Generate Markdown test reports for CI and coding agents.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@
 
 ### Reporters
 
+- [**@qualflare/vitest**](https://github.com/Qualflare/qualflare-vitest) — Reports results, retries, flakiness and nested steps to the Qualflare test-management platform. Makes no network calls; a separate CLI step uploads, so sharded runs merge into one report.
 - [**@testream/vitest-reporter**](https://docs.testream.app/reporters/vitest) — Teststream reporter with Jira integration.
 - [**vitest-llm-reporter**](https://github.com/hansjm10/vitest-llm-reporter) — Structured JSON output optimized for LLM parsing, with streaming support.
 - [**vitest-md-reporter**](https://github.com/robertozmc/vitest-md-reporter) — Generate Markdown test reports for CI and coding agents.


### PR DESCRIPTION
Adds [@qualflare/vitest](https://github.com/Qualflare/qualflare-vitest) (Apache-2.0, published with npm provenance) to Reporters.

It differs from the other entries in that section by making no network calls at all — it writes a report directory and a separate CLI step uploads it, which is what lets sharded runs merge into a single report. It reads `diagnostic()` for retry counts and Vitest's native `flaky` flag, and `task.meta` for author-supplied labels, links, priority and nested steps.

Sorted alphabetically before `@testream/vitest-reporter`, one resource, and the description avoids restating "for Vitest" per CONTRIBUTING. `prettier --check` passes locally against the repo's own config.